### PR TITLE
Save updated tiles rather than entire board after a move

### DIFF
--- a/src/main/java/commons/network/server/ServerRestController.java
+++ b/src/main/java/commons/network/server/ServerRestController.java
@@ -205,7 +205,8 @@ public class ServerRestController {
             response.setRedPlayerName(game.getRedPlayerName());
             response.setYellowPlayerName(game.getYellowPlayerName());
 
-            response.setBoardStates(game.getBoardStatesAsStrings());//.getInitialBoard().getCells()));
+            response.setInitialBoardState(game.getInitialBoardStateAsString());
+            response.setBoardStateUpdates(game.getBoardUpdatesAsStrings());
 
             response.setRedPlayerGameTime(game.getRedPlayerGameTime());
             response.setYellowPlayerGameTime(game.getYellowPlayerGameTime());

--- a/src/main/java/treasurehunter/board/BoardStateUpdate.java
+++ b/src/main/java/treasurehunter/board/BoardStateUpdate.java
@@ -1,0 +1,37 @@
+package treasurehunter.board;
+
+import java.io.Serializable;
+
+import treasurehunter.board.Tile.TileState;
+
+public class BoardStateUpdate implements Serializable {
+
+    private final Tile oldTile;
+    private final Tile newTile;
+
+    public BoardStateUpdate(final Tile oldTile, final Tile newTile) {
+        this.oldTile = oldTile.clone();
+        this.newTile = newTile.clone();
+    }
+
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+
+        sb.append(createTileString("old", oldTile));
+        sb.append(createTileString("new", newTile));
+
+        return sb.toString();
+    }
+
+    private String createTileString(String label, Tile tile) {
+        String stateString = "state" + tile.getState();
+        if (tile.getState() == TileState.RED || tile.getState() == TileState.YELLOW) {
+            stateString += "_" + oldTile.getOrientation();
+        }
+
+        int x = tile.getCoordinates().getX();
+        int y = tile.getCoordinates().getY();
+
+        return label + "-" + x + ":" + y + stateString;
+    }
+}

--- a/src/main/java/treasurehunter/board/Tile.java
+++ b/src/main/java/treasurehunter/board/Tile.java
@@ -24,6 +24,12 @@ public class Tile implements Serializable, Positionable {
         this.state = state;
     }
 
+    public Tile(Coordinate coordinate, TileState state, Orientation direction) {
+        this.coordinates = coordinate;
+        this.state = state;
+        this.direction = direction;
+    }
+
     public TileState getState() {
         return state;
     }
@@ -45,7 +51,9 @@ public class Tile implements Serializable, Positionable {
         return coordinates;
     }
 
-
+    public Tile clone() {
+        return new Tile(coordinates, state, direction);
+    }
 
     public enum TileState
     {

--- a/src/main/java/treasurehunter/board/TreasureHunterBoard.java
+++ b/src/main/java/treasurehunter/board/TreasureHunterBoard.java
@@ -58,18 +58,20 @@ public class TreasureHunterBoard implements Board<Tile> {
         return board[x][y];
     }
 
-    public void movePlayer(PlayerColor player, Move playerMove) {
-        Coordinate  playerTile = findPlayer(player);
+    public BoardStateUpdate movePlayer(PlayerColor player, Move playerMove) {
+        Tile playerTile = findPlayer(player);
 
-        int x = playerTile.getX();
-        int y = playerTile.getY();
+        int x = playerTile.getCoordinates().getX();
+        int y = playerTile.getCoordinates().getY();
+        int newX = x;
+        int newY = y;
 
-        Orientation playerDirection = board[x][y].getOrientation();
+        Orientation playerDirection = playerTile.getOrientation();
 
         switch (playerMove) {
             case MOVE_FORWARD:
-                int newX = x + playerDirection.xDirection();
-                int newY = y + playerDirection.yDirection();
+                newX = x + playerDirection.xDirection();
+                newY = y + playerDirection.yDirection();
 
                 Coordinate possibleNextTile = new Coordinate(newX, newY);
 
@@ -82,8 +84,8 @@ public class TreasureHunterBoard implements Board<Tile> {
                             // Deliberate fallthrough
                         case EMPTY:
                             board[x][y].setState(TileState.EMPTY);
-                            board[x + playerDirection.xDirection()][y + playerDirection.yDirection()].setState(TileState.valueOf(player.toString()));
-                            board[x + playerDirection.xDirection()][y + playerDirection.yDirection()].setOrientation(board[x][y].getOrientation());
+                            board[newX][newY].setState(TileState.valueOf(player.toString()));
+                            board[newX][newY].setOrientation(board[x][y].getOrientation());
                             break;
                         case WALL:
                         case RED:
@@ -95,7 +97,7 @@ public class TreasureHunterBoard implements Board<Tile> {
                 else {
                     // Player moved against outer wall
                 }
-                return;
+                break;
 
             case ROTATE_LEFT:
                 if (playerDirection == Orientation.UP) {
@@ -110,7 +112,7 @@ public class TreasureHunterBoard implements Board<Tile> {
                 else if (playerDirection == Orientation.RIGHT) {
                     board[x][y].setOrientation(Orientation.UP);
                 }
-                return;
+                break;
 
             case ROTATE_RIGHT:
                 if (playerDirection == Orientation.UP) {
@@ -125,18 +127,20 @@ public class TreasureHunterBoard implements Board<Tile> {
                 else if (playerDirection == Orientation.RIGHT) {
                     board[x][y].setOrientation(Orientation.DOWN);
                 }
-                return;
+                break;
 
             default:
                 throw new RuntimeException("Undefined player move! - " + playerMove.toString());
         }
+
+        return new BoardStateUpdate(board[x][y], board[newX][newY]);
     }
 
-    private Coordinate findPlayer(PlayerColor player) {
+    private Tile findPlayer(PlayerColor player) {
         for (int i = 0; i < numberOfColumns; i++) {
             for (int j = 0; j < numberOfRows; j++) {
                 if (board[i][j].getState().toString().equals(player.toString())) {
-                    return board[i][j].getCoordinates();
+                    return board[i][j];
                 }
             }
         }

--- a/src/main/java/treasurehunter/server/GameHandler.java
+++ b/src/main/java/treasurehunter/server/GameHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import commons.gameengine.board.BoardState;
 import commons.gameengine.board.PlayerColor;
 import treasurehunter.GameResult;
+import treasurehunter.board.BoardStateUpdate;
 import treasurehunter.board.TreasureHunterBoard;
 import treasurehunter.domain.Move;
 
@@ -37,8 +38,14 @@ public class GameHandler {
         final int treasuresLeft = GameResult.getTreasuresLeft(board);
 
         game.getTimer().stop(playerName);
-        board.movePlayer(playerColor, move);
-        game.addBoardState(new BoardState<>(board.getCells()));
+        BoardStateUpdate boardStateUpdate = board.movePlayer(playerColor, move);
+
+        if (!game.initialBoardIsSet()) {
+            game.setInitialBoardState(new BoardState<>(board.getCells()));
+        }
+        else {
+            game.addBoardStateUpdate(boardStateUpdate);
+        }
 
         if (treasuresLeft > GameResult.getTreasuresLeft(board)) {
             // Player picked up a treasure

--- a/src/main/java/treasurehunter/server/TreasureHunterGame.java
+++ b/src/main/java/treasurehunter/server/TreasureHunterGame.java
@@ -13,6 +13,7 @@ import commons.gameengine.board.PlayerColor;
 import commons.network.server.Game;
 import commons.network.server.GameTimer;
 import treasurehunter.GameResult;
+import treasurehunter.board.BoardStateUpdate;
 import treasurehunter.board.Tile;
 import treasurehunter.board.TreasureHunterBoard;
 
@@ -24,8 +25,8 @@ public class TreasureHunterGame implements Game, Serializable {
     private       long redPlayerGameTime;
     private       long yellowPlayerGameTime;
 
-    private final List<String[][]>       boardStatesAsStrings = new ArrayList<>();
-    private final List<BoardState<Tile>> boardStates          = new ArrayList<>();
+    private String[][] initialBoardStateAsString;
+    private final List<String> boardStateUpdatesAsStrings = new ArrayList<>();
     private final TreasureHunterBoard board;
     private final AtomicBoolean       isRedPlayerTurn       = new AtomicBoolean(true);
     private       AtomicInteger       yellowPlayerTreasures = new AtomicInteger(0);
@@ -73,10 +74,12 @@ public class TreasureHunterGame implements Game, Serializable {
         return name;
     }
 
-    public void addBoardState(BoardState<Tile> currentState) {
+    public void setInitialBoardState(final BoardState<Tile> boardState) {
+        this.initialBoardStateAsString = cellsAsStrings(boardState);
+    }
 
-        //boardStates.add(currentState);
-        boardStatesAsStrings.add(cellsAsStrings(currentState));
+    public void addBoardStateUpdate(final BoardStateUpdate boardStateUpdate) {
+        boardStateUpdatesAsStrings.add(boardStateUpdate.toString());
     }
 
     public String[][] cellsAsStrings(BoardState<Tile> boardState) {
@@ -98,13 +101,12 @@ public class TreasureHunterGame implements Game, Serializable {
         return cellsAsStrings;
     }
 
-    public List<String[][]> getBoardStatesAsStrings() {
-        return boardStatesAsStrings;
+    public String[][] getInitialBoardStateAsString() {
+        return initialBoardStateAsString;
     }
 
-
-    public List<BoardState<Tile>> getBoardStates() {
-        return boardStates;
+    public List<String> getBoardUpdatesAsStrings() {
+        return boardStateUpdatesAsStrings;
     }
 
     public synchronized TreasureHunterBoard getBoard() {
@@ -166,6 +168,10 @@ public class TreasureHunterGame implements Game, Serializable {
 
     public synchronized boolean isGameOver() {
         return GameResult.isGameOver(board);
+    }
+
+    public synchronized boolean initialBoardIsSet() {
+        return initialBoardStateAsString != null;
     }
 
     public synchronized void playerCollected(final PlayerColor playerColor) {

--- a/src/main/java/treasurehunter/server/response/GameSummaryResponse.java
+++ b/src/main/java/treasurehunter/server/response/GameSummaryResponse.java
@@ -16,7 +16,8 @@ public class GameSummaryResponse {
     private int              totalTreasures;
     private long             redPlayerGameTime;
     private long             yellowPlayerGameTime;
-    private List<String[][]> boardStates;
+    private String[][] initialBoardState;
+    private List<String> boardStateUpdates;
     private String gameStartDate;
     private String gameName;
     private String redPlayerName;
@@ -78,12 +79,20 @@ public class GameSummaryResponse {
         this.yellowPlayerName = yellowPlayerName;
     }
 
-    public void setBoardStates(List<String[][]> boardStates) {
-        this.boardStates = boardStates;
+    public void setInitialBoardState(String[][] initialBoardState) {
+        this.initialBoardState = initialBoardState;
     }
 
-    public List<String[][]> getBoardStates() {
-        return boardStates;
+    public String[][] getInitialBoardState() {
+        return initialBoardState;
+    }
+
+    public void setBoardStateUpdates(List<String> boardStateUpdates) {
+        this.boardStateUpdates = boardStateUpdates;
+    }
+
+    public List<String> getBoardStateUpdates() {
+        return boardStateUpdates;
     }
 
     public long getRedPlayerGameTime() {


### PR DESCRIPTION
Save only initial board state, and then the updated tiles for each move instead of entire board. Will reduce the amount of data we save and send through get request to /treasureHunterGameSummary to a fraction of what it currently is (and hopefully give the PI some extra breathingroom).