### PR TITLE
Only fetch games from server which we haven't stored client-side

### DIFF
--- a/src/main/java/commons/network/server/ServerRestController.java
+++ b/src/main/java/commons/network/server/ServerRestController.java
@@ -1,7 +1,9 @@
 package commons.network.server;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -194,11 +196,20 @@ public class ServerRestController {
 
     @CrossOrigin
     @RequestMapping("/treasureHunterGameSummary")
-    public List<treasurehunter.server.response.GameSummaryResponse> getTreasureHunterGameSummaries() {
+    public List<treasurehunter.server.response.GameSummaryResponse> getTreasureHunterGameSummaries(
+            @RequestParam(value = "lastSeenUUID", required = false) final UUID lastSeenUUID
+    ) {
         System.out.println("/treasureHunterGameSummary");
         final List<TreasureHunterGame>  games     = treasureHunterGameHandler.getFinishedGames();
         final List<treasurehunter.server.response.GameSummaryResponse> summaries = new ArrayList<>();
-        for (final TreasureHunterGame game : games) {
+
+        for (int i = games.size() -1; i >= 0; i--) {
+            final TreasureHunterGame game = games.get(i);
+
+            if (lastSeenUUID != null && lastSeenUUID.equals(game.getId())) {
+                break;
+            }
+
             final treasurehunter.server.response.GameSummaryResponse response = new treasurehunter.server.response.GameSummaryResponse();
             response.setUuid(game.getId());
             response.setGameName(game.getName());
@@ -221,6 +232,8 @@ public class ServerRestController {
             response.setGameStartDate(game.getGameStartTime().toString());
             summaries.add(response);
         }
+
+        Collections.reverse(summaries);
         return summaries;
     }
 }


### PR DESCRIPTION
When requesting gamesummaries from the server we can specify the last UUID we fetched as a parameter, causing the server to only include later games in the response. This way we won't have to constantly send massive responses when a lot of games have been played, every time we update the frontend table.

In the frontend, we now fetch new gamesummaries and store them locally, and then iterate over all existing local data to correctly populate the table for played/non-played games.

